### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@ password generator
 This is a simple python-coded program that allows you to keep track of accounts and their emails,passwords,and username. 
 It has a built-in password generator as well.
 Enjoy!
+[![Run on Repl.it](https://repl.it/badge/github/gsmith1269/password-gen)](https://repl.it/github/gsmith1269/password-gen)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@GraesonSmith1/password-gen).